### PR TITLE
refactor(cmd): extract the main code into its sub-command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "click==8.1.7",
     "platformdirs==4.2.0",
     "pydantic==2.6.4",
+    "pydantic-settings==2.2.1",
     "pygithub==2.3.0",
     "gitpython==3.1.42",
     "rich==13.7.1",

--- a/src/code_butler/cli/__init__.py
+++ b/src/code_butler/cli/__init__.py
@@ -1,26 +1,17 @@
-import re
-import tempfile
-import time
 from pathlib import Path
 
 import click
-import git
-from github import Auth, Github
 
 from code_butler.__about__ import __version__
 from rich.console import Console
 
 from code_butler.cli.application import Application
+from code_butler.cli.run import run
 
 
 @click.group(
     context_settings={"help_option_names": ["-h", "--help"]},
     invoke_without_command=True,
-)
-@click.option(
-    "--token",
-    "-t",
-    envvar="GITHUB_ACCESS_TOKEN",
 )
 @click.option(
     "--config",
@@ -29,18 +20,17 @@ from code_butler.cli.application import Application
     envvar="CODE_BUTLER_CONFIG",
     help="The path to a custom config file to use.",
 )
-@click.argument("repos", nargs=-1)
 @click.version_option(version=__version__, prog_name="Code Butler")
 @click.pass_context
-def code_butler(ctx, token, repos, config_file):
+def code_butler(ctx, config_file):
     if config_file:
         path = Path(config_file)
-        app = Application(token, path)
+        app = Application(path)
         if not path.is_file():
             print(f"The selected config file `{path}` does not exist.")
             ctx.exit(1)
     else:
-        app = Application(token)
+        app = Application()
         if not app.config_file.path.is_file():
             try:
                 app.config_file.restore()
@@ -59,80 +49,12 @@ def code_butler(ctx, token, repos, config_file):
     # Store it so it can be used by sub-commands
     ctx.obj = app
 
-    if not app.token:
+    if not app.config_file.config.github.token:
         print("No token provided.")
         ctx.exit(1)
 
-    # TODO: extract the rest into its own sub-command
-    do_stuff(app.token, repos)
 
-
-def do_stuff(token, repos):
-    client = Github(auth=Auth.Token(token))
-
-    with tempfile.TemporaryDirectory() as temp_dir:
-        for repo in repos:
-            org_name, repo_name = repo.split("/")
-
-            print(f"Repo: {org_name}/{repo_name}")
-            repo = git.Repo.clone_from(
-                f"git@github.com:{org_name}/{repo_name}.git",
-                Path(temp_dir) / org_name / repo_name,
-                depth=1,
-            )
-            upstream_repo = client.get_repo(f"{org_name}/{repo_name}")
-            print(f"Cloned repo in: {repo.working_dir}")
-
-            found = False
-
-            for search, pattern, replace in (
-                (
-                    "::save-state name=",
-                    r"::save-state name=([^:]*)::(.*)",
-                    r'\g<1>=\g<2> >> "$GITHUB_STATE"',
-                ),
-                (
-                    "::set-output name=",
-                    r"::set-output name=([^:]*)::(.*)",
-                    r'\g<1>=\g<2> >> "$GITHUB_OUTPUT"',
-                ),
-            ):
-                for file in repo.git.execute(
-                    ["git", "grep", "-l", search]
-                ).splitlines():
-                    print(f"{pattern} - File: {file}")
-                    content = (Path(repo.working_dir) / file).read_text()
-                    found = True
-                    content = re.sub(pattern, replace, content)
-                    print("Updated file...")
-                    (Path(repo.working_dir) / file).write_text(content)
-                    repo.index.add([file])
-
-            if found:
-                print("Committing...")
-                repo.index.commit(
-                    "chore(ci): replace deprecated save-state and set-output commands"
-                )
-                print("Creating fork...")
-                fork = client.get_user().create_fork(upstream_repo)
-                print(f"Adding fork as remote... {fork.clone_url}")
-                repo.create_remote("fork", fork.clone_url)
-                # wait for GH to fork it properly
-                time.sleep(2)
-                print("Pushing...")
-                repo.remotes.fork.push()
-
-                print("Creating the PR...")
-                pullrequest = upstream_repo.create_pull(
-                    base="main",
-                    head="{}:{}".format(client.get_user().login, "main"),
-                    draft=True,
-                    title="chore(ci): replace deprecated save-state and set-output commands",
-                    body="See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/",
-                )
-                print(f"PR: {pullrequest.html_url}")
-
-    client.close()
+code_butler.add_command(run)
 
 
 def main():  # no cov

--- a/src/code_butler/cli/application.py
+++ b/src/code_butler/cli/application.py
@@ -6,17 +6,10 @@ from code_butler.config.file import ConfigFile
 
 
 class Application:
-    def __init__(self, token: str | None, config_file: Path | None = None):
+    def __init__(self, config_file: Path | None = None):
         self.__config_file = ConfigFile(config_file)
-        self.__token = token
 
     @property
     def config_file(self) -> ConfigFile:
         self.__config_file.load()
         return self.__config_file
-
-    @property
-    def token(self) -> str | None:
-        if self.__token is None:
-            return self.config_file.config.github.token
-        return self.__token

--- a/src/code_butler/cli/run/__init__.py
+++ b/src/code_butler/cli/run/__init__.py
@@ -1,0 +1,86 @@
+import re
+import tempfile
+import time
+from pathlib import Path
+from typing import Iterable
+
+import click
+import git
+from github import Github, Auth
+
+from code_butler.cli import Application
+
+
+@click.command(short_help="Analyze a repo then fix and open a PR if needed.")
+@click.pass_obj
+@click.argument("repos", nargs=-1)
+def run(
+    app: Application,
+    repos: Iterable[str],
+):
+    client = Github(auth=Auth.Token(app.config_file.config.github.token))
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        for repo in repos:
+            org_name, repo_name = repo.split("/")
+
+            print(f"Repo: {org_name}/{repo_name}")
+            repository = git.Repo.clone_from(
+                f"git@github.com:{org_name}/{repo_name}.git",
+                Path(temp_dir) / org_name / repo_name,
+                depth=1,
+            )
+            upstream_repo = client.get_repo(f"{org_name}/{repo_name}")
+            print(f"Cloned repo in: {repository.working_dir}")
+
+            found = False
+
+            for search, pattern, replace in (
+                (
+                    "::save-state name=",
+                    r"::save-state name=([^:]*)::(.*)",
+                    r'\g<1>=\g<2> >> "$GITHUB_STATE"',
+                ),
+                (
+                    "::set-output name=",
+                    r"::set-output name=([^:]*)::(.*)",
+                    r'\g<1>=\g<2> >> "$GITHUB_OUTPUT"',
+                ),
+            ):
+                for file in repository.git.execute(
+                    ["git", "grep", "-l", search]
+                ).splitlines():  # type: ignore
+                    print(f"{pattern} - File: {str(file)}")
+                    path = Path(repository.working_dir) / str(file)
+                    content = path.read_text()
+                    found = True
+                    content = re.sub(pattern, replace, content)
+                    print("Updated file...")
+                    path.write_text(content)
+                    repository.index.add([str(file)])
+
+            if found:
+                print("Committing...")
+                repository.index.commit(
+                    "chore(ci): replace deprecated save-state and set-output commands"
+                )
+                print("Creating fork...")
+                fork = upstream_repo.create_fork()
+                print(f"Adding fork as remote... {fork.clone_url}")
+                repository.create_remote("fork", fork.clone_url)
+                # wait for GH to fork it properly
+                time.sleep(2)
+                print("Pushing...")
+                repository.remotes.fork.push()
+
+                print("Creating the PR...")
+                pullrequest = upstream_repo.create_pull(
+                    base="main",
+                    head=f"{client.get_user().login}:main",
+                    draft=True,
+                    title="chore(ci): replace deprecated save-state and set-output commands",
+                    body="See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/",
+                )
+                print(f"PR: {pullrequest.html_url}")
+
+    client.close()

--- a/src/code_butler/config/github.py
+++ b/src/code_butler/config/github.py
@@ -1,5 +1,6 @@
-from pydantic import BaseModel
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-class Github(BaseModel):
+class Github(BaseSettings):
     token: str = ""
+    model_config = SettingsConfigDict(env_prefix="CODE_BUTLER_GITHUB_")

--- a/tests/cli/test_application.py
+++ b/tests/cli/test_application.py
@@ -1,9 +1,0 @@
-from code_butler.cli import Application
-
-
-def test_token_from_cli(config_file):
-    assert Application("the-token", config_file.path).token == "the-token"
-
-
-def test_token_from_file(config_file):
-    assert Application(None, config_file.path).token == "my-token"

--- a/tests/config/test_github.py
+++ b/tests/config/test_github.py
@@ -1,0 +1,13 @@
+import os
+from unittest import mock
+from code_butler.config.github import Github
+
+
+@mock.patch.dict(os.environ, {"CODE_BUTLER_GITHUB_TOKEN": "my-token"})
+def test_read_token_from_env_variable():
+    assert Github().token == "my-token"
+
+
+@mock.patch.dict(os.environ, {})
+def test_no_token():
+    assert Github().token == ""


### PR DESCRIPTION
I'll add more command so we need to move it to its own sub-command. `run` is a very bad name, we'll rename it later I think.